### PR TITLE
fix go get for v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tommy-muehle/go-mnd
+module github.com/tommy-muehle/go-mnd/v2
 
 go 1.12
 


### PR DESCRIPTION
when changing the major version of a go lib, go requires that the package path is changed as well (adding `/v2` at the en in `go.mod`)

```go
$ mkdir mnd-error                                                           [22:15:13]
$ cd mnd-error                                                              [22:15:21]
$ go mod init example.com/mnd-error                               [22:15:24]
go: creating new go.mod: module example.com/mnd-error

$ go get github.com/tommy-muehle/go-mnd                           [22:15:41]
go: downloading golang.org/x/tools v0.0.0-20190221204921-83362c3779f5
go: extracting golang.org/x/tools v0.0.0-20190221204921-83362c3779f5
go: finding golang.org/x/tools v0.0.0-20190221204921-83362c3779f5

$ cat go.mod                                                      [22:15:54]
module example.com/mnd-error

go 1.13

require github.com/tommy-muehle/go-mnd v1.3.0 // indirect <--- 1.3.0

$ go get github.com/tommy-muehle/go-mnd@v2.0.0                    [22:16:02]
go: finding github.com/tommy-muehle/go-mnd v2.0.0
go: finding github.com/tommy-muehle/go-mnd v2.0.0
go get github.com/tommy-muehle/go-mnd@v2.0.0: github.com/tommy-muehle/go-mnd@v2.0.0: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2
```