### PR TITLE
Add GitLab CI Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ jobs:
           args: ./...
 ```
 
+### GitLab CI
+
+You can run go-mnd inside a GitLab CI pipeline as follows:
+
+```
+stages:
+  - lint
+
+go:lint:mnd:
+  stage: lint
+  needs: []
+  image: golang:latest
+  before_script:
+    - go get -u github.com/tommy-muehle/go-mnd/cmd/mnd
+    - go mod tidy
+    - go mod vendor
+  script:
+    - go vet -vettool $(which mnd) ./...
+```
+
 ### Homebrew
 
 To install with [Homebrew](https://brew.sh/), run:


### PR DESCRIPTION
Add example for using within GitLab CI in `README.md`.

<!--- Provide a general summary of your changes in the title above -->

### Description
I added a GitLab CI configuration in the readme file below the GitHub actions section.

### Motivation and Context
Some persons including myself use GitLab CI (around 10+% according to [this webpage](https://www.slintel.com/tech/source-code-management/gitlab-market-share)), and providing a configuration example makes it easy to set up GitLab CI using go-mnd (like GitHub Actions)
It doesn't fix and open issue.

### How Has This Been Tested?
I have tested this with one of my projects, and here is the result (available [here](https://storage.googleapis.com/gitlab-gprd-artifacts/52/61/5261101681c860ca8e6083857ab724c5aea48b50334df645e288c4871182f9dc/2020_11_13/848692211/932382521/job.log?response-content-type=text%2Fplain%3B%20charset%3Dutf-8&response-content-disposition=inline&GoogleAccessId=gitlab-object-storage-prd@gitlab-production.iam.gserviceaccount.com&Signature=xPDryMGP78n%2BvgajXgRY2KqZeXaNgJ8E8q9JjiOTgxteii%2F2pL%2F79i7seElm%0Ab%2F7JEZvuMph6OTvzCeBsxfm3QizYkU%2BZCzzZxXReSnErsc%2F9X%2FbWH6196tSe%0AeZ8FRGk9RRBo%2Bc2Rao0mb3RLwZqn5E%2FSiPY7A8RNWhlsDEHxQnctql%2Byk7yb%0AC6SMMq97a0lagNFByBlzIIb6G3KqeSUs6a5cBBDA0YgzRFwnWQgBn2TXzYeb%0AjYDW0Nn7YnbTWPC1A3aj07rrFSKRXt6ymI%2BgcgFbSze0KRBEzj%2B7Fn2nb2JW%0ATI8CHzQXoknM2n161LG5oXJb3Sg1Eih1eq42FcbN7w%3D%3D&Expires=1605293532))
```
[0KRunning with gitlab-runner 13.6.0-rc1 (d83ac56c)
[0;m[0K  on docker-auto-scale 72989761
[0;msection_start:1605292596:resolve_secrets
[0K[0K[36;1mResolving secrets[0;m
[0;msection_end:1605292596:resolve_secrets
[0Ksection_start:1605292596:prepare_executor
[0K[0K[36;1mPreparing the "docker+machine" executor[0;m
[0;m[0KUsing Docker executor with image golang:latest ...
[0;m[0KPulling docker image golang:latest ...
[0;m[0KUsing docker image sha256:1b8b0ceece59e2e8b4b03b46cc88d3a91fe05757f1038397fb1dc9478fd3dd52 for golang:latest with digest golang@sha256:7ca7ffe692fa0fb6a142d4bdf5c28b6d7b3e32dc9a25eea9596ae1935135d7eb ...
[0;msection_end:1605292623:prepare_executor
[0Ksection_start:1605292623:prepare_script
[0K[0K[36;1mPreparing environment[0;m
[0;mRunning on runner-72989761-project-22371408-concurrent-0 via runner-72989761-srm-1605292546-cb7f8f2c...
section_end:1605292626:prepare_script
[0Ksection_start:1605292626:get_sources
[0K[0K[36;1mGetting source from Git repository[0;m
[0;m[32;1m$ eval "$CI_PRE_CLONE_SCRIPT"[0;m
[32;1mFetching changes with git depth set to 50...[0;m
Initialized empty Git repository in /builds/crypto-checker1/image/.git/
[32;1mCreated fresh repository.[0;m
[32;1mChecking out d1a0feb3 as master...[0;m

[32;1mSkipping Git submodules setup[0;m
section_end:1605292627:get_sources
[0Ksection_start:1605292627:step_script
[0K[0K[36;1mExecuting "step_script" stage of the job script[0;m
[0;m[32;1m$ go get -u github.com/tommy-muehle/go-mnd/cmd/mnd[0;m
go: downloading github.com/tommy-muehle/go-mnd v1.3.0
go: found github.com/tommy-muehle/go-mnd/cmd/mnd in github.com/tommy-muehle/go-mnd v1.3.0
go: downloading golang.org/x/tools v0.0.0-20190221204921-83362c3779f5
go: golang.org/x/tools upgrade => v0.0.0-20201113164040-559c4acc06b6
go: downloading golang.org/x/tools v0.0.0-20201113164040-559c4acc06b6
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading golang.org/x/mod v0.3.0
go: golang.org/x/xerrors upgrade => v0.0.0-20200804184101-5ec99f83aff1
[32;1m$ go mod tidy[0;m
go: downloading github.com/pelletier/go-toml v1.8.1
go: downloading github.com/srwiley/oksvg v0.0.0-20200311192757-870daf9aa564
go: downloading gopkg.in/fogleman/gg.v1 v1.3.0
go: downloading github.com/srwiley/rasterx v0.0.0-20200120212402-85cb7272f5e9
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading golang.org/x/image v0.0.0-20200927104501-e162460cd6b5
go: downloading github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
go: downloading golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
go: downloading golang.org/x/text v0.3.3
[32;1m$ go mod vendor[0;m
[32;1m$ go vet -vettool $(which mnd) ./...[0;m
# gitlab.com/colourdelete/image/internals
internals/image.go:102:13: Magic number: 1, in <argument> detected
internals/main.go:34:11: Magic number: 789, in <assign> detected
internals/main.go:39:10: Magic number: 64, in <assign> detected
internals/main.go:43:11: Magic number: 123, in <assign> detected
internals/main.go:48:10: Magic number: 64, in <assign> detected
internals/main.go:52:11: Magic number: 456, in <assign> detected
internals/main.go:57:10: Magic number: 64, in <assign> detected
internals/main.go:61:11: Magic number: 456, in <assign> detected
internals/main.go:66:10: Magic number: 64, in <assign> detected
internals/main.go:70:11: Magic number: 123, in <assign> detected
internals/main.go:75:10: Magic number: 64, in <assign> detected
internals/main.go:79:11: Magic number: 123, in <assign> detected
internals/main.go:84:10: Magic number: 64, in <assign> detected
section_end:1605292646:step_script
[0Ksection_start:1605292646:cleanup_file_variables
[0K[0K[36;1mCleaning up file based variables[0;m
[0;msection_end:1605292646:cleanup_file_variables
[0K[31;1mERROR: Job failed: exit code 1
[0;m
```

As seen above, go-mnd works (it detects that my code is bad!).
