### PR TITLE
Support ignoring Go built-in functions when excluding functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The ```-ignored-numbers``` option let's you define a comma separated list of num
 For example: `-ignored-numbers=1000,10_000,3.14159264`
 
 The ```-ignored-functions``` option let's you define a comma separated list of function name regexp patterns to exclude.  
-For example: `-ignored-functions=math.*,http.StatusText`
+For example: `-ignored-functions=math.*,http.StatusText,make`
 
 The ```-ignored-files``` option let's you define a comma separated list of filename regexp patterns to exclude.  
 For example: `-ignored-files=magic_.*.go,.*_numbers.go`

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -44,7 +44,7 @@ func TestCanIgnoreFunctions(t *testing.T) {
 	options.String("checks", "argument", "")
 	options.String("excludes", "", "")
 	options.String("ignored-files", "", "")
-	options.String("ignored-functions", "math.*", "")
+	options.String("ignored-functions", "math.*,make", "")
 	options.String("ignored-numbers", "", "")
 
 	analyzer := Analyzer

--- a/checks/argument.go
+++ b/checks/argument.go
@@ -74,6 +74,10 @@ func (a *ArgumentAnalyzer) checkCallExpr(expr *ast.CallExpr) {
 				return
 			}
 		}
+	case *ast.Ident:
+		if a.config.IsIgnoredFunction(f.Name) {
+			return
+		}
 	}
 
 	for i, arg := range expr.Args {

--- a/testdata/src/ignored/functions/functions.go
+++ b/testdata/src/ignored/functions/functions.go
@@ -18,3 +18,9 @@ func example3() {
 	// ignored via configuration
 	math.Acos(1.5)
 }
+
+func example4() {
+	// ignored via configuration
+	a := make([]int, 0, 10)
+	a[0] = 1
+}


### PR DESCRIPTION
The Go AST identifies built-in functions as an `ast.Ident` instead of an `ast.SelectorExpr`. Add a case to ignore them when checking for ignored functions.

Closes #28 