### PR TITLE
fix: wasted regexp

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,11 +44,10 @@ func WithOptions(options ...Option) *Config {
 
 func WithIgnoredFunctions(excludes string) Option {
 	return func(config *Config) {
-		if excludes == "" {
-			return
-		}
-
 		for _, exclude := range strings.Split(excludes, ",") {
+			if exclude == "" {
+				continue
+			}
 			config.IgnoredFunctions = append(config.IgnoredFunctions, regexp.MustCompile(exclude))
 		}
 	}
@@ -56,11 +55,10 @@ func WithIgnoredFunctions(excludes string) Option {
 
 func WithIgnoredFiles(excludes string) Option {
 	return func(config *Config) {
-		if excludes == "" {
-			return
-		}
-
 		for _, exclude := range strings.Split(excludes, ",") {
+			if exclude == "" {
+				continue
+			}
 			config.IgnoredFiles = append(config.IgnoredFiles, regexp.MustCompile(exclude))
 		}
 	}
@@ -68,11 +66,10 @@ func WithIgnoredFiles(excludes string) Option {
 
 func WithIgnoredNumbers(numbers string) Option {
 	return func(config *Config) {
-		if numbers == "" {
-			return
-		}
-
 		for _, number := range strings.Split(numbers, ",") {
+			if number == "" {
+				continue
+			}
 			config.IgnoredNumbers[config.removeDigitSeparator(number)] = struct{}{}
 		}
 	}
@@ -89,6 +86,9 @@ func WithCustomChecks(checks string) Option {
 		}
 
 		for _, name := range strings.Split(checks, ",") {
+			if name == "" {
+				continue
+			}
 			config.Checks[name] = true
 		}
 	}


### PR DESCRIPTION
Removes unnecessary checks & adds ones tool really need.

### Description
This `PR` enable `go-mnd` to ignore empty settings (e.g `",some,,,,"`)

### Motivation and Context
While adding docs to `golangci-lint` I found that empty regular expression added always to `go-mnd` if `ignored-files` option supplied. Found that any other settings have this issues too. While this is isn't important issue it's (slightly) affects the performance of any tool (`golangci-lint`) using package.


### How Has This Been Tested?
`make test` with existing tests.
