### PR TITLE
Ignore both floating representations of 0, 1

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,8 +20,10 @@ func DefaultConfig() *Config {
 		IgnoredNumbers: map[string]struct{}{
 			"0":   {},
 			"0.0": {},
+			"0.":  {},
 			"1":   {},
 			"1.0": {},
+			"1.":  {},
 		},
 		IgnoredFiles: []*regexp.Regexp{
 			regexp.MustCompile(`_test.go`),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,10 +25,16 @@ func TestWithCustomChecks(t *testing.T) {
 	assert.False(c.IsCheckEnabled("condition"))
 }
 
-func TestZeroIsIgnoredNumber(t *testing.T) {
+func TestIgnoredNumbers(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.True(config.DefaultConfig().IsIgnoredNumber("0"))
+	// Sync with DefaultConfig()
+	// Ignored numbers are: 0, 1, and their two floating expressions
+	ignoredNumbers := []string{ "0", "0.0", "0.", "1", "1.0", "1." }
+
+	for _, n := range ignoredNumbers {
+		assert.True(config.DefaultConfig().IsIgnoredNumber(n))
+	}
 }
 
 func TestCanIgnoreCustomNumbers(t *testing.T) {


### PR DESCRIPTION
Improves https://github.com/tommy-muehle/go-mnd/commit/9a7adaf33f01691e795de3cf1cd082508ef77e59 by also ignoring `0.`, `1.`
