### PR TITLE
Dockerfile: Use unversioned golang:alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG GO_VERSION=1.16
-
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM golang:alpine AS builder
 RUN apk add --update --no-cache make git curl gcc libc-dev
 RUN mkdir -p /build
 WORKDIR /build
@@ -8,7 +6,7 @@ COPY . /build/
 RUN go mod download
 RUN go build -o go-mnd cmd/mnd/main.go
 
-FROM golang:${GO_VERSION}-alpine
+FROM golang:alpine
 RUN apk add --update --no-cache bash git gcc libc-dev
 COPY --from=builder /build/go-mnd /bin/go-mnd
 COPY entrypoint.sh /bin/entrypoint.sh


### PR DESCRIPTION
The Dockerfile hardcodes the use of golang:1.16-alpine.

Both golang 1.16 and the alpine version used in this image are
unmaintained at this point, with most likely some known unfixed security
issues.

This PR switches to an unversioned golang/alpine image, which should
ensure we always use an up-to-date image.
We can switch back to a versioned image if this causes issues and it
turns out we need more predictability on the golang version used.